### PR TITLE
Use `via` for match in routes

### DIFF
--- a/lib/devise_sms_activable/routes.rb
+++ b/lib/devise_sms_activable/routes.rb
@@ -4,7 +4,7 @@ module ActionDispatch::Routing
     protected
       def devise_sms_activation(mapping, controllers)
         resource :sms_activation, :only => [:new, :create], :path => mapping.path_names[:sms_activation], :controller => controllers[:sms_activations] do
-          match :consume, :path => mapping.path_names[:consume], :as => :consume
+          match :consume, :path => mapping.path_names[:consume], :as => :consume, via: %i(patch post get)
           get :insert, :path => mapping.path_names[:insert], :as => :insert
         end
       end


### PR DESCRIPTION
Rails' routes requires the use of `via` for routes using `match`.
